### PR TITLE
Switch from deprecated win1803 pipeline image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ trigger:
       - v*
 
 pool:
-  vmImage: 'win1803'
+  vmImage: 'vs2017-win2016'
 
 steps:
 - task: PowerShell@2


### PR DESCRIPTION
The `win1803` Azure Pipeline images is being retired. Switch to recommended alternative;  `vs2017-win2016`.

https://devblogs.microsoft.com/devops/removing-older-images-in-azure-pipelines-hosted-pools/